### PR TITLE
Upgrade `pages.yml` artifact versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
       # GitHub Pages.
       # Docs: https://github.com/actions/upload-pages-artifact
       - name: 🏺 Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # (2) Deploy job
   deploy:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
 ```
 3. Go to your repository's *"Settings"* Page. Click *"Pages"* in the sidebar. Under *"Build & Deployment"*, click on the *"Source"* dropdown. Choose ***"GitHub Actions"***.
 


### PR DESCRIPTION
Closes #1.

Bumping `upload-pages-artifact` from v1 to [v3](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0) and `deploy-pages` from v1 to [v4](https://github.com/actions/deploy-pages/releases/tag/v4.0.2). (Tested on eecs485staff repo)